### PR TITLE
Update for PySide6 Support.

### DIFF
--- a/libs/xlOil_Python/Package/xloil/gui/qtpy.py
+++ b/libs/xlOil_Python/Package/xloil/gui/qtpy.py
@@ -21,13 +21,13 @@ def _create_Qt_app():
     def qt_msg_handler(msg_type, msg_log_context, msg_string):
 
         level = 'info'
-        if msg_type == QtCore.QtDebugMsg:
+        if msg_type == QtCore.QtMsgType.QtDebugMsg:
             level = 'debug'
-        elif msg_type == QtCore.QtInfoMsg:
+        elif msg_type == QtCore.QtMsgType.QtInfoMsg:
             level = 'info'
-        elif msg_type == QtCore.QtWarningMsg:
+        elif msg_type == QtCore.QtMsgType.QtWarningMsg:
             level = 'warn'
-        elif msg_type == QtCore.QtCriticalMsg or msg_type == QtCore.QtFatalMsg:
+        elif msg_type == QtCore.QtMsgType.QtCriticalMsg or msg_type == QtCore.QtMsgType.QtFatalMsg:
             level = 'error'
 
         # Qt raises this on shutdown. No idea why, but don't want it to trigger

--- a/src/xlOil-COM/Connect.cpp
+++ b/src/xlOil-COM/Connect.cpp
@@ -28,18 +28,7 @@ namespace xloil
         __uuidof(Excel::Application),
         NULL,
         CLSCTX_LOCAL_SERVER);
-      if (hr == S_OK)
-      {
-          return app.Detach();
-      }
-      else
-      {
-          _com_error error(hr);
-          throw ComConnectException(
-              utf16ToUtf8(
-                  fmt::format(L"Failed to create Application object. COM Error {0:#x}: {1}",
-                      (size_t)error.Error(), error.ErrorMessage())).c_str());
-      }
+      return hr == S_OK ? app.Detach() : nullptr;
     }
 
     Excel::_Application* applicationObjectFromWindow(HWND xlmainHandle)
@@ -61,11 +50,9 @@ namespace xloil
       auto hwnd2 = FindWindowExA(xlmainHandle, 0, "XLDESK", NULL);
       auto hwnd3 = FindWindowExA(hwnd2, 0, "EXCEL7", NULL);
       Excel::Window* pWindow = NULL;
-      HRESULT hr = AccessibleObjectFromWindow(hwnd3, (DWORD)OBJID_NATIVEOM,
-          __uuidof(Excel::Window),
-          (void**)&pWindow);
-
-      if ( hr == S_OK)
+      if (AccessibleObjectFromWindow(hwnd3, (DWORD)OBJID_NATIVEOM,
+        __uuidof(Excel::Window),
+        (void**)&pWindow) == S_OK)
       {
         auto parent = pWindow->Parent;
         Excel::_WorkbookPtr parentWorkbook(parent);
@@ -73,14 +60,6 @@ namespace xloil
         
         auto result = parentWorkbook->Application;
         return result.Detach();
-      }
-      else
-      {
-        _com_error error(hr);
-        throw ComConnectException(
-            utf16ToUtf8(
-                fmt::format(L"Failed to create Application object from window handle. COM Error {0:#x}: {1}. {2}",
-                    (size_t)error.Error(), error.ErrorMessage(), error.Description())).c_str());
       }
       return nullptr;
     }


### PR DESCRIPTION
Hi Steven, hopefully an easy one to review! 

Convert Pyside Enum references to long form to adapt to breaking changes from PySide5->PySide6 See FAQ for more details https://www.pythonguis.com/faq/pyqt6-vs-pyside6/

I ran the manual test `PythonTestUI.xlsm` and confirmed the panes still worked. 

I used vscode so didn't quite manage to compile locally but rather tested with local edit of a 0.19.1 installation which worked alright. 