### PR TITLE
Feature/issue 128/int casting

### DIFF
--- a/libs/xlOil_Python/TypeConversion/BasicTypes.cpp
+++ b/libs/xlOil_Python/TypeConversion/BasicTypes.cpp
@@ -61,12 +61,10 @@ namespace xloil
         {
           if (!PyLong_Check(obj))
             XLO_THROW("Expected python int, got '{0}'", to_string(obj));
-          int overflow_indicator;
-          long output = PyLong_AsLongAndOverflow((PyObject*)obj, &overflow_indicator);
-          if (overflow_indicator)
-          {
+          int overflowIndicator;
+          long output = PyLong_AsLongAndOverflow((PyObject*)obj, &overflowIndicator);
+          if (overflowIndicator)
             return ExcelObj(PyFloat_AsDouble((PyObject*)obj)); // since obj is not a float, this will call obj.__float__() which exists since PyLong_Check passed above
-          }
           else
             return ExcelObj(output);
         }

--- a/libs/xlOil_Python/TypeConversion/BasicTypes.cpp
+++ b/libs/xlOil_Python/TypeConversion/BasicTypes.cpp
@@ -65,7 +65,7 @@ namespace xloil
           long output = PyLong_AsLongAndOverflow((PyObject*)obj, &overflow_indicator);
           if (overflow_indicator)
           {
-            return ExcelObj(PyFloat_AsDouble((PyObject*)obj)); // will call obj.__float__() which exists since we've confirmed it's a long already above
+            return ExcelObj(PyFloat_AsDouble((PyObject*)obj)); // since obj is not a float, this will call obj.__float__() which exists since PyLong_Check passed above
           }
           else
             return ExcelObj(output);

--- a/libs/xlOil_Python/TypeConversion/BasicTypes.cpp
+++ b/libs/xlOil_Python/TypeConversion/BasicTypes.cpp
@@ -61,7 +61,14 @@ namespace xloil
         {
           if (!PyLong_Check(obj))
             XLO_THROW("Expected python int, got '{0}'", to_string(obj));
-          return ExcelObj(PyLong_AsLong((PyObject*)obj));
+          int overflow_indicator;
+          long output = PyLong_AsLongAndOverflow((PyObject*)obj, &overflow_indicator);
+          if (overflow_indicator)
+          {
+            return ExcelObj(PyFloat_AsDouble((PyObject*)obj)); // will call obj.__float__() which exists since we've confirmed it's a long already above
+          }
+          else
+            return ExcelObj(output);
         }
         static constexpr char* ourName = "int";
       };

--- a/libs/xlOil_Python/TypeConversion/BasicTypes.h
+++ b/libs/xlOil_Python/TypeConversion/BasicTypes.h
@@ -403,7 +403,13 @@ namespace xloil
         }
         else if (PyLong_Check(p))
         {
-          return ExcelObj(PyLong_AsLong(p));
+          int overflowIndicator;
+          auto out = PyLong_AsLongAndOverflow(p, &overflowIndicator);
+          if (overflowIndicator)
+            return ExcelObj(PyFloat_AsDouble(p));
+          else
+            return ExcelObj(out);
+
         }
         else if (PyFloat_Check(p))
         {

--- a/libs/xlOil_Python/TypeConversion/BasicTypes.h
+++ b/libs/xlOil_Python/TypeConversion/BasicTypes.h
@@ -130,9 +130,9 @@ namespace xloil
         PyObject* operator()(bool x)   const { return operator()(int(x)); }
         PyObject* operator()(double x) const
         {
-          long i;
+          long long i;
           if (floatingToInt(x, i))
-            return PyLong_FromLong(i);
+            return PyLong_FromLongLong(i);
           return nullptr;
         }
         


### PR DESCRIPTION
PR for https://github.com/cunnane/xloil/issues/128

Validated on Python 3.11 64bit using the following udfs to confirm the input and both output converters. 


```python
@xlo.func()
def largeval_explicit()->int:
    return 2**31+1
@xlo.func()
def largeval_implicit():
    return 2**31+1

@xlo.func(local=False)
def mirror_deets(x:int)->str:
    return str(x)
```

The  Python C-API functions used are all part of the stable ABI so should be fine for all python versions.

On a sidenote: I took a stab at adding some unit tests which include Python elements but the changes got a bit messy since none of the other tests depend on python so I thought I'd ask where would you recommend such unit tests live? As part of the `UnitTests` project or a new project? 
