### PR TITLE
feat: Extend ObjectCache to better support RTD publishing

### DIFF
--- a/include/xloil/ObjectCache.h
+++ b/include/xloil/ObjectCache.h
@@ -7,385 +7,456 @@
 #include <unordered_map>
 #include <string_view>
 #include <mutex>
+#include <type_traits>
 
 namespace xloil
 {
-  template<class T>
-  struct CacheUniquifier
-  {
-    CacheUniquifier()
+    template<class T>
+    struct CacheUniquifier
     {
-      static wchar_t chr = L'\xC38';
-      value = chr++;
-    }
-    wchar_t value;
-  };
-
-  namespace detail
-  {
-    template<uint16_t NPadding>
-    inline auto writeCacheId(
-      const CallerInfo& caller, const std::wstring_view& optionalName)
-    {
-      constexpr auto addressStyle = AddressStyle::RC | AddressStyle::NOQUOTE;
-      const auto nameLength = optionalName.size();
-      const auto pstrLength = 
-        caller.addressLength(addressStyle)
-        + optionalName.size() 
-        + NPadding + 1u; // Padding for the ",XX" at the end and 1 for the uniquifier
-      PString pascalStr((uint16_t)pstrLength);
-      auto* buf = pascalStr.pstr() + 1;
-
-      int nWritten = 1; // Leave space for uniquifier
-
-      nWritten += caller.writeAddress(buf, pstrLength - 1, addressStyle);
-      // Check for a negative return condition from the above. This should not
-      // be possible as we made the buffer larger than the addres length
-      assert(nWritten - 1 > 0 && nWritten <= caller.addressLength(addressStyle) + 1);
-
-      if (nameLength != 0)
-        wmemcpy_s(buf + nWritten - 1, pstrLength - nWritten, optionalName.data(), nameLength);
-
-      // Fix up length
-      pascalStr.resize(uint16_t(nWritten + nameLength + NPadding));
-
-      return pascalStr;
-    }
-
-    // We need to explicitly define our own lookup function for undordered_map
-    // to use string_view objects without copying.  In std::map the find function 
-    // is templated on the key type so we're just replicating that behaviour.
-    template<class Val>
-    struct Lookup : public std::unordered_map<std::wstring, Val>
-    {
-      using base = typename std::unordered_map<std::wstring, Val>;
-
-      template <class T>
-      _NODISCARD typename base::const_iterator search(const T& _Keyval) const
-      {
-        size_type _Bucket = std::hash<T>()(_Keyval) & _Mask;
-        for (auto _Where = begin(_Bucket); _Where != end(_Bucket); ++_Where)
-          if (_Where->first == _Keyval)
-            return _Where;
-        return (end());
-      }
-      template <class T>
-      _NODISCARD typename base::iterator search(const T& _Keyval)
-      {
-        size_type _Bucket = std::hash<T>()(_Keyval) & _Mask;
-        for (auto _Where = begin(_Bucket); _Where != end(_Bucket); ++_Where)
-          if (_Where->first == _Keyval)
-            return _Where;
-        return (end());
-      }
+        CacheUniquifier()
+        {
+            static wchar_t chr = L'\xC38';
+            value = chr++;
+        }
+        wchar_t value;
     };
 
-    template<typename TObj>
-    class CellCache
+    namespace detail
+    {
+        template<uint16_t NPadding>
+        inline auto writeCacheId(
+            const CallerInfo& caller, const std::wstring_view& optionalName)
+        {
+            constexpr auto addressStyle = AddressStyle::RC | AddressStyle::NOQUOTE;
+            const auto nameLength = optionalName.size();
+            const auto pstrLength =
+                caller.addressLength(addressStyle)
+                + optionalName.size()
+                + NPadding + 1u; // Padding for the ",XX" at the end and 1 for the uniquifier
+            PString pascalStr((uint16_t)pstrLength);
+            auto* buf = pascalStr.pstr() + 1;
+
+            int nWritten = 1; // Leave space for uniquifier
+
+            nWritten += caller.writeAddress(buf, pstrLength - 1, addressStyle);
+            // Check for a negative return condition from the above. This should not
+            // be possible as we made the buffer larger than the addres length
+            assert(nWritten - 1 > 0 && nWritten <= caller.addressLength(addressStyle) + 1);
+
+            if (nameLength != 0)
+                wmemcpy_s(buf + nWritten - 1, pstrLength - nWritten, optionalName.data(), nameLength);
+
+            // Fix up length
+            pascalStr.resize(uint16_t(nWritten + nameLength + NPadding));
+
+            return pascalStr;
+        }
+
+        // We need to explicitly define our own lookup function for undordered_map
+        // to use string_view objects without copying.  In std::map the find function
+        // is templated on the key type so we're just replicating that behaviour.
+        template<class Val>
+        struct Lookup : public std::unordered_map<std::wstring, Val>
+        {
+            using base = typename std::unordered_map<std::wstring, Val>;
+
+            template <class T>
+            _NODISCARD typename base::const_iterator search(const T& _Keyval) const
+            {
+                size_type _Bucket = std::hash<T>()(_Keyval) & _Mask;
+                for (auto _Where = begin(_Bucket); _Where != end(_Bucket); ++_Where)
+                    if (_Where->first == _Keyval)
+                        return _Where;
+                return (end());
+            }
+            template <class T>
+            _NODISCARD typename base::iterator search(const T& _Keyval)
+            {
+                size_type _Bucket = std::hash<T>()(_Keyval) & _Mask;
+                for (auto _Where = begin(_Bucket); _Where != end(_Bucket); ++_Where)
+                    if (_Where->first == _Keyval)
+                        return _Where;
+                return (end());
+            }
+        };
+
+        template<typename TObj>
+        class CellCache
+        {
+        private:
+            size_t _calcId;
+            std::vector<TObj> _objects;
+            TObj _obj;
+
+        public:
+            CellCache(TObj&& obj, size_t calcId)
+                : _calcId(calcId)
+                , _obj(std::move(obj))
+            {
+            }
+
+            auto count() const { return (uint16_t)(_objects.size() + 1); }
+
+            auto add(TObj&& obj, size_t calcId)
+            {
+                if (_calcId != calcId)
+                {
+                    std::swap(_obj, obj);
+                    _calcId = calcId;
+                    _objects.clear();
+                }
+                else
+                    _objects.emplace_back(std::forward<TObj>(obj));
+                return _objects.size();
+            }
+
+            const TObj* fetch(size_t i) const
+            {
+                if (i == 0)
+                    return &_obj;
+                else if (i <= _objects.size())
+                    return &_objects[i - 1];
+                else
+                    return nullptr;
+            }
+        };
+
+        /// <summary>
+        /// Alternative to CellCache: holds only a single value, not tied to _calcId.
+        /// </summary>
+        template<typename TObj>
+        class SingleValueCache
+        {
+        private:
+            TObj _obj;
+
+        public:
+            SingleValueCache(TObj&& obj)
+                : _obj(std::move(obj))
+            {
+            }
+
+            SingleValueCache(TObj&& obj, size_t _calcId)
+                : _obj(std::move(obj))
+            {
+                //calcId is ignored here
+            }
+
+            // For compatibility with CellCache interface
+            auto count() const { return 1u; }
+
+
+            // alias for add with calcId
+            auto add(TObj&& obj, size_t _calcId)
+            {
+                return add(std::move(obj));
+            }
+            // Overwrites the stored value with the new one
+            auto add(TObj&& obj)
+            {
+                _obj = std::move(obj);
+                return 0u; // Always position 0
+            }
+
+            // Always returns pointer to the single value if i == 0, else nullptr
+            const TObj* fetch(size_t i) const
+            {
+                return (i == 0) ? &_obj : nullptr;
+            }
+        };
+
+        template<typename T>
+        struct is_valid_cache_type : std::false_type {};
+
+        template<typename T>
+        struct is_valid_cache_type<detail::CellCache<T>> : std::true_type {};
+
+        template<typename T>
+        struct is_valid_cache_type<detail::SingleValueCache<T>> : std::true_type {};
+    }
+
+    /// <summary>
+    /// Creates a dictionary of TObj indexed by cell address.
+    /// The cell address used is determined from the currently executing cell
+    /// when the "add" method is called.
+    ///
+    /// This class is used to allow data which we cannot or do not want to write
+    /// to an Excel sheet to be passed between Excel user functions.
+    ///
+    /// The cache add a single character uniquifier TUniquifier to returned
+    /// reference strings. This allows very fast rejection of invalid references
+    /// during lookup. The uniquifier should be choosen to be unlikely to occur
+    /// at the start of a string before a '['.
+    ///
+    /// Example
+    /// -------
+    /// <code>
+    /// static ObjectCache<PyObject*>, L'&', false> theCache
+    ///     = ObjectCache<PyObject*>, L'&', false > ();
+    ///
+    /// ExcelObj refStr = theCache.add(new PyObject());
+    /// PyObject* obj = theCache.fetch(refStr);
+    /// </code>
+    /// </summary>
+
+    template<
+        class TObj,
+        class TUniquifier,
+        class TCache = detail::CellCache<TObj>,
+        typename = std::enable_if_t<detail::is_valid_cache_type<TCache>::value>
+    // Restrict TCache to only be detail::CellCache or detail::SingleValueCache using std::enable_if and type traits
+
+    >
+    class ObjectCache
     {
     private:
-      size_t _calcId;
-      std::vector<TObj> _objects;
-      TObj _obj;
+        typedef ObjectCache<TObj, TUniquifier, TCache> self;
+        typedef TCache CacheType;
+
+        detail::Lookup<CacheType> _cache;
+        mutable std::mutex _cacheLock;
+
+        size_t _calcId;
+
+        std::shared_ptr<const void> _calcEndHandler;
+        std::shared_ptr<const void> _workbookCloseHandler;
+
+        void onAfterCalculate()
+        {
+            // Called by Excel event so will always be synchonised
+            ++_calcId; // Wraps at MAX_UINT - but this doesn't matter
+        }
+
+        /// <summary>
+        /// Used to append cell count to end of reference
+        /// </summary>
+        static constexpr uint8_t PADDING = 2;
+
+        TUniquifier _uniquifier;
+
+        ObjectCache()
+            : _calcId(1)
+        {}
 
     public:
-      CellCache(TObj&& obj, size_t calcId)
-        : _calcId(calcId)
-        , _obj(std::move(obj))
-      {}
-
-      auto count() const { return (uint16_t)(_objects.size() + 1); }
-
-      auto add(TObj&& obj, size_t calcId)
-      {
-        if (_calcId != calcId)
+        static auto create(bool reapOnWorkbookClose = true)
         {
-          std::swap(_obj, obj);
-          _calcId = calcId;
-          _objects.clear();
-        }
-        else
-          _objects.emplace_back(std::forward<TObj>(obj));
-        return _objects.size();
-      }
+            auto p = std::shared_ptr<ObjectCache>(new ObjectCache);
+            p->_calcEndHandler =
+                xloil::Event::AfterCalculate().weakBind(std::weak_ptr<ObjectCache>(p), &self::onAfterCalculate);
 
-      const TObj* fetch(size_t i) const
-      {
-        if (i == 0)
-          return &_obj;
-        else if (i <= _objects.size())
-          return &_objects[i - 1];
-        else
-          return nullptr;
-      }
+            if (reapOnWorkbookClose)
+                p->_workbookCloseHandler =
+                xloil::Event::WorkbookAfterClose().weakBind(std::weak_ptr<ObjectCache>(p), &self::onWorkbookClose);
+
+            return p;
+        }
+
+        const TObj* fetch(const std::wstring_view& key) const
+        {
+            if (key.size() < PADDING) return nullptr;
+
+            const auto iResult = readCount(key[key.size() - 1]);
+            const auto cacheKey = key.substr(0, key.size() - PADDING);
+
+            std::scoped_lock lock(_cacheLock);
+            const auto found = _cache.search(cacheKey);
+
+            if (found == _cache.end())
+                return nullptr;
+
+            const TObj* result = found->second.fetch(iResult);
+            return result;
+        }
+
+        ExcelObj add(
+            TObj&& obj,
+            const CallerInfo& caller = CallerInfo(),
+            const std::wstring_view& name = std::wstring_view())
+        {
+            auto fullKey = detail::writeCacheId<PADDING>(caller, name);
+            return _add(std::move(obj), std::move(fullKey));
+        }
+
+        ExcelObj add(
+            TObj&& obj,
+            const std::wstring_view& key)
+        {
+            PString fullKey((uint16_t)key.size() + PADDING + 2u);
+            std::copy(key.cbegin(), key.cend(), fullKey.begin() + 2u);
+            return _add(std::move(obj), std::move(fullKey));
+        }
+
+        /// <summary>
+        /// Remove the given cache reference and any associated objects. This
+        /// should only be called with manually specifed cache reference strings.
+        /// Note the counter (,NNN) after the cache reference is ignored if
+        /// specifed and all matching objects are removed.
+        /// </summary>
+        /// <param name="key">cache reference to remove</param>
+        /// <returns>true if removal succeeded, otherwise false</returns>
+        bool erase(const std::wstring_view& key)
+        {
+            auto cacheKey = key.substr(0, key.length() - PADDING);
+
+            std::scoped_lock lock(_cacheLock);
+            auto found = _cache.search(cacheKey);
+            if (found == _cache.end())
+                return false;
+            _cache.erase(found);
+            return true;
+        }
+
+        void onWorkbookClose(const wchar_t* wbName)
+        {
+            // Called by Excel Event so will always be synchonised
+            const auto len = wcslen(wbName);
+            auto i = _cache.begin();
+            while (i != _cache.end())
+            {
+                // Key looks like UNIQ[WbName]BlahBlah, so skip 2 chars and check for match
+                if (wcsncmp(wbName, i->first.c_str() + 2, len) == 0)
+                    i = _cache.erase(i);
+                else
+                    ++i;
+            }
+        }
+
+        auto begin() const
+        {
+            return _cache.cbegin();
+        }
+
+        auto end() const
+        {
+            return _cache.cend();
+        }
+
+        std::wstring writeKey(
+            const std::wstring_view& cacheKey,
+            uint16_t count) const
+        {
+            std::wstring key;
+            key.resize(cacheKey.length() + PADDING);
+            key = cacheKey;
+            writeCount(key.data() + cacheKey.length(), count);
+            return key;
+        }
+
+        bool valid(const std::wstring_view& cacheString)
+        {
+            return cacheString.size() > 4
+                && cacheString[0] == _uniquifier.value
+                && cacheString[1] == L'['
+                && cacheString[cacheString.length() - PADDING] == L',';
+        }
+
+    private:
+        ExcelObj _add(
+            TObj&& obj,
+            PString&& fullKey)
+        {
+            fullKey[0] = _uniquifier.value;
+            // In most cases the second char is already '[' unless the caller is
+            // not a worksheet function or a custom cache string is used
+            fullKey[1] = L'[';
+
+            auto cacheKey = fullKey.view(0, fullKey.length() - PADDING);
+
+            decltype(_cache)::iterator found;
+
+            uint16_t iPos = 0;
+            {
+                std::scoped_lock lock(_cacheLock);
+
+                found = _cache.search(cacheKey);
+                if (found == _cache.end())
+                {
+                    found = _cache.emplace(
+                        std::pair(
+                            std::wstring(cacheKey),
+                            CacheType(std::forward<TObj>(obj), _calcId))).first;
+                }
+                else
+                {
+                    iPos = (uint16_t)found->second.add(
+                        std::forward<TObj>(obj), _calcId);
+                }
+            }
+
+            writeCount(fullKey.end() - PADDING, iPos);
+
+            return ExcelObj(std::move(fullKey));
+        }
+
+        size_t readCount(wchar_t count) const
+        {
+            return (size_t)(count - 65);
+        }
+
+        /// Add cell object count in form ",X"
+        void writeCount(wchar_t* key, uint16_t iPos) const
+        {
+            static_assert(PADDING == 2);
+            key[0] = L',';
+            // An offset of 65 means we start with 'A'
+            key[1] = (wchar_t)(iPos + 65);
+        }
     };
-  }
 
-  /// <summary>
-  /// Creates a dictionary of TObj indexed by cell address.
-  /// The cell address used is determined from the currently executing cell
-  /// when the "add" method is called.
-  /// 
-  /// This class is used to allow data which we cannot or do not want to write
-  /// to an Excel sheet to be passed between Excel user functions.
-  /// 
-  /// The cache add a single character uniquifier TUniquifier to returned 
-  /// reference strings. This allows very fast rejection of invalid references
-  /// during lookup. The uniquifier should be choosen to be unlikely to occur 
-  /// at the start of a string before a '['.
-  /// 
-  /// Example
-  /// -------
-  /// <code>
-  /// static ObjectCache<PyObject*>, L'&', false> theCache
-  ///     = ObjectCache<PyObject*>, L'&', false > ();
-  /// 
-  /// ExcelObj refStr = theCache.add(new PyObject());
-  /// PyObject* obj = theCache.fetch(refStr);
-  /// </code>
-  /// </summary>
-  template<class TObj, class TUniquifier>
-  class ObjectCache
-  {
-  private:
-    typedef ObjectCache<TObj, TUniquifier> self;
-    typedef detail::CellCache<TObj> CellCache;
-
-    detail::Lookup<CellCache> _cache;
-    mutable std::mutex _cacheLock;
-
-    size_t _calcId;
-
-    std::shared_ptr<const void> _calcEndHandler;
-    std::shared_ptr<const void> _workbookCloseHandler;
-
-    void onAfterCalculate()
+    template<typename T, typename TCache = detail::CellCache<T> >
+    struct ObjectCacheFactory
     {
-      // Called by Excel event so will always be synchonised
-      ++_calcId; // Wraps at MAX_UINT - but this doesn't matter
+        using cache_type = decltype(*ObjectCache<T, CacheUniquifier<T>, TCache>::create());
+        static cache_type& cache() {
+            static auto theInstance = ObjectCache<T, CacheUniquifier<T>, TCache>::create();
+            return *theInstance;
+        }
+    };
+
+    /// <summary>
+    /// Constructs an object of type <typeparamref name="T"/> and adds
+    /// it to a cache of identically typed objects. Returns the key
+    /// string as an <see cref="ExcelObj"/>.  Essentially a wrapper
+    /// around <code><![CDATA[cache.add(make_unique<T>(...))]]></code>.
+    /// The cache is automatically constructed if it doesn't already
+    /// exist.
+    /// </summary>
+    template<typename T, typename... Args>
+    inline auto makeCached(Args&&... args)
+    {
+        return ObjectCacheFactory<std::unique_ptr<const T>>::cache().add(
+            std::make_unique<T>(std::forward<Args>(args)...));
+    }
+
+    // TODO: consider abrogated caching where simple types are just returned un-cached
+    template<typename T>
+    inline auto addCached(
+        const T* ptr,
+        const std::wstring_view& name = std::wstring_view())
+    {
+        return ObjectCacheFactory<std::unique_ptr<const T>>::cache().add(
+            std::unique_ptr<const T>(ptr), CallerInfo(), name);
+    }
+
+    template<typename T>
+    auto getPyRTDObjectCache()
+    {
+         return &ObjectCacheFactory<T, detail::SingleValueCache<T>>::cache();
     }
 
     /// <summary>
-    /// Used to append cell count to end of reference
+    /// Retrieves an object of type <typeparamref name="T"/> given its key.
+    /// Returns nullptr if not found.
     /// </summary>
-    static constexpr uint8_t PADDING = 2;
-
-    TUniquifier _uniquifier;
-
-    ObjectCache()
-      : _calcId(1)
-    {}
-
-  public:
-    static auto create(bool reapOnWorkbookClose = true)
+    template<typename T, typename TCache = detail::CellCache<std::unique_ptr<const T>> >
+    inline const T* getCached(const std::wstring_view& key)
     {
-      auto p = std::shared_ptr<ObjectCache>(new ObjectCache);
-      p->_calcEndHandler =
-        xloil::Event::AfterCalculate().weakBind(std::weak_ptr<ObjectCache>(p), &self::onAfterCalculate);
+        if (!ObjectCacheFactory<std::unique_ptr<const T>, TCache>::cache().valid(key))
+            return nullptr;
 
-      if (reapOnWorkbookClose)
-        p->_workbookCloseHandler =
-        xloil::Event::WorkbookAfterClose().weakBind(std::weak_ptr<ObjectCache>(p), &self::onWorkbookClose);
-
-      return p;
-    }
-
-    const TObj* fetch(const std::wstring_view& key) const
-    {
-      if (key.size() < PADDING) return nullptr;
-
-      const auto iResult = readCount(key[key.size() - 1]);
-      const auto cacheKey = key.substr(0, key.size() - PADDING);
-
-      std::scoped_lock lock(_cacheLock);
-      const auto found = _cache.search(cacheKey);
-
-      return found == _cache.end()
-        ? nullptr
-        : found->second.fetch(iResult);
-    }
-
-    ExcelObj add(
-      TObj&& obj,
-      const CallerInfo& caller = CallerInfo(),
-      const std::wstring_view& name = std::wstring_view())
-    {
-      auto fullKey = detail::writeCacheId<PADDING>(caller, name);
-      return _add(std::move(obj), std::move(fullKey));
-    }
-
-    ExcelObj add(
-      TObj&& obj,
-      const std::wstring_view& key)
-    {
-      PString fullKey((uint16_t)key.size() + PADDING + 2u);
-      std::copy(key.cbegin(), key.cend(), fullKey.begin() + 2u);
-      return _add(std::move(obj), std::move(fullKey));
-    }
-
-    /// <summary>
-    /// Remove the given cache reference and any associated objects. This
-    /// should only be called with manually specifed cache reference strings.
-    /// Note the counter (,NNN) after the cache reference is ignored if 
-    /// specifed and all matching objects are removed.
-    /// </summary>
-    /// <param name="key">cache reference to remove</param>
-    /// <returns>true if removal succeeded, otherwise false</returns>
-    bool erase(const std::wstring_view& key)
-    {
-      auto cacheKey = key.substr(0, key.length() - PADDING);
-
-      std::scoped_lock lock(_cacheLock);
-      auto found = _cache.search(cacheKey);
-      if (found == _cache.end())
-        return false;
-      _cache.erase(found);
-      return true;
-    }
-
-    void onWorkbookClose(const wchar_t* wbName)
-    {
-      // Called by Excel Event so will always be synchonised
-      const auto len = wcslen(wbName);
-      auto i = _cache.begin();
-      while (i != _cache.end())
-      {
-        // Key looks like UNIQ[WbName]BlahBlah, so skip 2 chars and check for match
-        if (wcsncmp(wbName, i->first.c_str() + 2, len) == 0)
-          i = _cache.erase(i);
-        else
-          ++i;
-      }
-    }
-
-    auto begin() const
-    {
-      return _cache.cbegin();
-    }
-
-    auto end() const
-    {
-      return _cache.cend();
-    }
-
-    std::wstring writeKey(
-      const std::wstring_view& cacheKey,
-      uint16_t count) const
-    {
-      std::wstring key;
-      key.resize(cacheKey.length() + PADDING);
-      key = cacheKey;
-      writeCount(key.data() + cacheKey.length(), count);
-      return key;
-    }
-
-    bool valid(const std::wstring_view& cacheString)
-    {
-      return cacheString.size() > 4
-        && cacheString[0] == _uniquifier.value
-        && cacheString[1] == L'['
-        && cacheString[cacheString.length() - PADDING] == L',';
-    }
-
-  private:
-    ExcelObj _add(
-      TObj&& obj,
-      PString&& fullKey)
-    {
-      fullKey[0] = _uniquifier.value;
-      // In most cases the second char is already '[' unless the caller is 
-      // not a worksheet function or a custom cache string is used
-      fullKey[1] = L'[';
-
-      auto cacheKey = fullKey.view(0, fullKey.length() - PADDING);
-
-      decltype(_cache)::iterator found;
-
-      uint16_t iPos = 0;
-      {
-        std::scoped_lock lock(_cacheLock);
-
-        found = _cache.search(cacheKey);
-        if (found == _cache.end())
-        {
-          found = _cache.emplace(
-            std::pair(
-              std::wstring(cacheKey),
-              CellCache(std::forward<TObj>(obj), _calcId))).first;
-        }
-        else
-        {
-          iPos = (uint16_t)found->second.add(
-            std::forward<TObj>(obj), _calcId);
-        }
-      }
-
-      writeCount(fullKey.end() - PADDING, iPos);
-
-      return ExcelObj(std::move(fullKey));
-    }
-
-    size_t readCount(wchar_t count) const
-    {
-      return (size_t)(count - 65);
-    }
-
-    /// Add cell object count in form ",X"
-    void writeCount(wchar_t* key, uint16_t iPos) const
-    {
-      static_assert(PADDING == 2);
-      key[0] = L',';
-      // An offset of 65 means we start with 'A'
-      key[1] = (wchar_t)(iPos + 65);
-    }
-  };
-
-  template<typename T>
-  struct ObjectCacheFactory
-  {
-    using cache_type = decltype(*ObjectCache<T, CacheUniquifier<T>>::create());
-    static cache_type& cache() {
-      static auto theInstance = ObjectCache<T, CacheUniquifier<T>>::create();
-      return *theInstance;
-    }
-  };
-
-  /// <summary>
-  /// Constructs an object of type <typeparamref name="T"/> and adds
-  /// it to a cache of identically typed objects. Returns the key
-  /// string as an <see cref="ExcelObj"/>.  Essentially a wrapper
-  /// around <code><![CDATA[cache.add(make_unique<T>(...))]]></code>.
-  /// The cache is automatically constructed if it doesn't already
-  /// exist.
-  /// </summary>
-  template<typename T, typename... Args>
-  inline auto makeCached(Args&&... args)
-  {
-    return ObjectCacheFactory<std::unique_ptr<const T>>::cache().add(
-      std::make_unique<T>(std::forward<Args>(args)...));
-  }
-
-  // TODO: consider abrogated caching where simple types are just returned un-cached
-  template<typename T>
-  inline auto addCached(
-    const T* ptr,
-    const std::wstring_view& name = std::wstring_view())
-  {
-    return ObjectCacheFactory<std::unique_ptr<const T>>::cache().add(
-      std::unique_ptr<const T>(ptr), CallerInfo(), name);
-  }
-
-  /// <summary>
-  /// Retrieves an object of type <typeparamref name="T"/> given its key.
-  /// Returns nullptr if not found.
-  /// </summary>
-  template<typename T>
-  inline const T* getCached(const std::wstring_view& key)
-  {
-    if (!ObjectCacheFactory<std::unique_ptr<const T>>::cache().valid(key))
-      return nullptr;
-
-    const auto* found = ObjectCacheFactory<std::unique_ptr<const T>>::cache().fetch(key);
-    return found ? found->get() : nullptr;
-  }
-}
+        const auto* found = ObjectCacheFactory<std::unique_ptr<const T>, TCache>::cache().fetch(key);
+        return found ? found->get() : nullptr;
+    };
+};

--- a/libs/xlOil_Python/PyCache.cpp
+++ b/libs/xlOil_Python/PyCache.cpp
@@ -125,19 +125,32 @@ namespace xloil
         caller ? CallerInfo(ExcelObj(caller)) : CallerInfo(),
         name);
     }
+    ExcelObj addCachedSingle(
+        const py::object& obj,
+        const wchar_t* key)
+    {
+        return getPyRTDObjectCache< py::object >()->add(
+            py::object(obj), key);
+    }
 
     bool pyCacheGet(const std::wstring_view& str, py::object& obj)
     {
       auto& cache = *PyCache::instance()._cache;
-      if (!cache.valid(str))
-        return false;
+      return pyCacheGet(str, obj, cache);
+    }
 
-      const auto* p = cache.fetch(str);
-      if (!p)
-        return false;
+    template <typename TCache>
+    bool pyCacheGet(const std::wstring_view& str, py::object& obj, TCache& cache = *PyCache::instance()._cache)
+    {
+        if (!cache.valid(str))
+            return false;
 
-      obj = *p;
-      return true;
+        const auto* p = cache.fetch(str);
+        if (!p)
+            return false;
+
+        obj = *p;
+        return true;
     }
 
     namespace

--- a/libs/xlOil_Python/PyCache.h
+++ b/libs/xlOil_Python/PyCache.h
@@ -12,12 +12,16 @@ namespace xloil
     /// string in an ExcelObj. Must hold the GIL to call.
     /// </summary>
     ExcelObj pyCacheAdd(const pybind11::object& obj, const wchar_t* caller = nullptr);
+    ExcelObj addCachedSingle(const pybind11::object& obj, const wchar_t* key);
 
     /// <summary>
     /// Tries to fetch an object give a cache reference string, returning
     /// true if sucessful. Must hold the GIL to call.
     /// </summary>
     bool pyCacheGet(const std::wstring_view& cacheStr, pybind11::object& obj);
+
+    template <typename TCache>
+    bool pyCacheGet(const std::wstring_view& cacheStr, pybind11::object& obj, TCache& cache);
 
     static constexpr uint16_t CACHE_KEY_MAX_LEN = XL_FULL_ADDRESS_RC_MAX_LEN;
   }

--- a/libs/xlOil_Python/PyRtd.cpp
+++ b/libs/xlOil_Python/PyRtd.cpp
@@ -298,9 +298,9 @@ namespace xloil
         }
         else
         {
-          xlValue = converter
-            ? (*converter)(ptr)
-            : FromPyObj()(ptr);
+            xlValue = converter
+                ? (*converter)(ptr)
+                : FromPyObj < detail::ReturnToSingleValueCache, true > (detail::ReturnToSingleValueCache{topic})(ptr);
         }
 
         py::gil_scoped_release releaseGil;
@@ -317,7 +317,7 @@ namespace xloil
           return py::none();
         return PySteal<>(converter
           ? (*converter)(*value)
-          : PyFromAny()(*value));
+            : PyFromAny()(*value));
       }
 
       py::object peek(const wchar_t* topic, IPyFromExcel* converter = nullptr)


### PR DESCRIPTION
Addresses #141
Problem:
- Cache key collisions during RTD publishing due to invalid CallerInfo
- Race conditions with fast-ticking data

Solution:
- Add ReturnToSingleValueCache converter that writes to pre-specified cache keys. This eliminates our need to use `CallerInfo` which isn't accesible from the RTDPublisher context.
- Introduce `SingleValueCache` with fixed size of one element to prevent race conditions
- Extend ObjectCache with template parameterization while maintaining backward compatibility
- Add support for explicitly providing cache instances in `pyCacheGet`
- Create a new ObjectCache for RTD values.

Notes:
- We need to ensure that `TIsScalar` is set to True to avoid mangling iterable values when using ReturnToSingleValueCache. There may be a better way to configure this.
- I added an additional `pyCacheGet` call to `PyFromCache` to check for `SingleValueCache` objects. This adds a bit more overhead to strings but I'm thinking it's relatively minor due to the is valid check's efficiency.
- I called the new cache getter `getPyRTDObjectCache` since that's currently the only usecase. Could be renamed if another usecase arises.
- I used a getter in order to avoid having to include the `detail::SingleValueCache` class directly elsewhere.