### PR TITLE
feat: Extend ObjectCache to better support RTD publishing (using unordered_map)

### DIFF
--- a/include/xloil/RtdServer.h
+++ b/include/xloil/RtdServer.h
@@ -318,7 +318,17 @@ namespace xloil
         const wchar_t* topic) = 0;
 
     /// <summary>
-    /// Looks up a value for a specified topic, but does not subscribe.
+    /// This calls Excel's RTD function, which means the
+    /// calling cell will be recalculated every time a new value is published.
+    /// 
+    /// Does not return a value. Just subscribes to updates
+    /// </summary>
+    /// <param name="topic"></param>
+    virtual void
+      subscribe_to_calc_triggers(
+        const wchar_t* topic) = 0;
+
+    /// <summary>/// Looks up a value for a specified topic, but does not subscribe.
     /// If there is no publisher for the topic, the returned pointer will
     /// be null. If there is no published value, it will point to N/A.
     /// This does not call Excel's RTD function.
@@ -341,6 +351,15 @@ namespace xloil
       publish(
         const wchar_t* topic,
         ExcelObj&& value) = 0;
+
+    /// <summary>
+    /// Trigger an update to be propagated for the provided rtd Topic
+    /// </summary>
+    /// <param name="topic"></param>
+    /// <returns>True if the producer was found and the value was set</returns>
+    virtual bool
+      trigger_update(
+        const wchar_t* topic) = 0;
 
     /// <summary>
     /// Drops the producer for a topic by calling RtdPublisher::stop, then waits

--- a/src/xlOil-COM/RtdManager.cpp
+++ b/src/xlOil-COM/RtdManager.cpp
@@ -243,9 +243,18 @@ namespace xloil
           value = make_shared<ExcelObj>(CellError::NA);
         return value;
       }
+      void subscribe_to_calc_triggers(const wchar_t* topic) override
+      {
+        callRtd(topic);
+      }
       bool publish(const wchar_t* topic, ExcelObj&& value) override
       {
         server().update(topic, make_shared<ExcelObj>(std::move(value)));
+        return true;
+      }
+      bool trigger_update(const wchar_t* topic) override
+      {
+        server().update(topic, make_shared<ExcelObj>(CellError::NA));
         return true;
       }
       shared_ptr<const ExcelObj> 


### PR DESCRIPTION
Addresses #141
Problem:
- Cache key collisions during RTD publishing due to invalid CallerInfo
- Race conditions with fast-ticking data

Solution:
- return publish all pyRTD values an unordered_map rather than publishing to the cell cache.
- Skip converting to and from excel values and simply directly store the py::objects.
- Extend RtdServer to allow for easier use of the calculation trigger functionality without needing to provide excel values.

Notes:
- I'm not sure if there are other usecases where the values would be subscribed to. Given the existing raceconditions I'm not sure there would be any serious ones.
- I believe there are some cleanup concerns I need to address.
- I think there could be a way to avoid checking `_rtdCache.find` by specifying an allocator in the STL template but it felt much more verbose when I attempted it.
  - The default allocator of py::object was not a suitable substitute for py::none()
- subscribe_to_calc_triggers is just a pass through but I felt the naming was helpful to convey intent.
